### PR TITLE
Use `HOME` directory to avoid hard-coded path

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,7 @@ Also don't forget to checkout our [wiki](https://github.com/omarcostahamido/PVM/
 ## Development
 
 ### Logs
-The PVM execution logs will be recorded in each RPI device memory. These will be stored in the `/log/` directory, which will be created if it doesn't exist yet.
-
-`pvm.py` would generate logs during execution, which will be stored in the `/log/` directory under the working directory of PVM. It would be created if it doesn't exist yet.
+`pvm.py` would generate logs during execution, which will be stored in the `log/` directory under the working directory of PVM. It would be created if it doesn't exist yet.
 
 Name convention for each log file is `{:%Y-%m-%d %H:%M:%S}.log`
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Also don't forget to checkout our [wiki](https://github.com/omarcostahamido/PVM/
 ## Development
 
 ### Logs
-`pvm.py` would generate logs during execution, which will be stored in the `log/` directory under the working directory of PVM. It would be created if it doesn't exist yet.
+Logs will be recorded by `pvm.py` during execution. These will be stored in the `log/` folder, within the install directory of `PVM` on the Raspberry Pi device. This folder will be created if it doesn't exist yet.
 
 Name convention for each log file is `{:%Y-%m-%d %H:%M:%S}.log`
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To use NTP to sync all Raspberry Pis' time in local network, please follow secti
 
 ## Videos
 
-Please save all the videos in the `/home/pi/Videos/` folder for autostart.
+Please save all the videos in the `/home/{your_user_name}/Videos/` folder for autostart. On Rapsberry Pi, your default directory should be `/home/pi/Videos/`.
 
 
 ## Running
@@ -133,7 +133,7 @@ on the terminal run
 
 after the last line add
 
-`@lxterminal -e sh /home/pi/PVM/launch.sh`
+`@lxterminal -e sh $HOME/PVM/launch.sh`
 
 Note: this is assuming that you clone this repo on your raspberry pi in the main /home/pi folder and followed the steps in the <a target="_self" href="#installation">Installation</a> section above.
 
@@ -210,10 +210,11 @@ Also don't forget to checkout our [wiki](https://github.com/omarcostahamido/PVM/
 ## Development
 
 ### Logs
+The PVM execution logs will be recorded in each RPI device memory. These will be stored in the `/log/` directory, which will be created if it doesn't exist yet.
 
-All logs for each time each RPI is stored in the `log` folder in the current directory. If it doesn't exist yet, a new directory named `log` would be created.
+`pvm.py` would generate logs during execution, which will be stored in the `/log/` directory under the working directory of PVM. It would be created if it doesn't exist yet.
 
-Name convention for each file is `{:%Y-%m-%d %H:%M:%S}.log`
+Name convention for each log file is `{:%Y-%m-%d %H:%M:%S}.log`
 
 All output from the console is synchronized to the file in real-time.
 
@@ -227,6 +228,6 @@ If you close the program and then reopen it, a new log file will be created.
 
 ## Run the test
 
-You could write tests for your combination of commands in the `test.py` file. Simply run `python3 test.py` from the console will run it. When the test script is started, it will first **kill any existing `pvm.py` processes**, and then spawn a new one to test the commands, and end it again after test is finished.
+You could write tests for your combination of commands in the `test.py` file. Simply run `python3 test.py` on the console to perform the tests. When the test script is started, it will first **kill any existing `pvm.py` processes**, and then spawn a new one to test the commands, and end it again after test is finished.
 
 ## Known limitations

--- a/launch.sh
+++ b/launch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-. /home/pi/PVM/PVM/bin/activate
-python /home/pi/PVM/pvm.py
+. ${HOME}/PVM/PVM/bin/activate
+python ${HOME}/PVM/pvm.py

--- a/pvm.py
+++ b/pvm.py
@@ -11,7 +11,7 @@ import sys
 # Place your videos in this folder for autostart
 HOME = str(Path.home()) + "/"  # The home directory, e.g. /home/pi/
 LOG_PATH = HOME + "PVM/log/"
-PEFIX_PATH = HOME + "Videos/"
+PREFIX_PATH = HOME + "Videos/"
 VIDEO_PATH = "jellyfish720p.mp4"
 IS_FILE_SET = False
 
@@ -53,9 +53,9 @@ def parse_commands(*args):
 	# TODO: Create another python file to control two display
 	try:
 		if command=="file":
-			_logger.info("File set: %s", PEFIX_PATH + value)
+			_logger.info("File set: %s", PREFIX_PATH + value)
 			IS_FILE_SET = True
-			media = OMXPlayer(PEFIX_PATH + value, dbus_name='org.mpris.MediaPlayer2.omxplayer', args=['--loop'])
+			media = OMXPlayer(PREFIX_PATH + value, dbus_name='org.mpris.MediaPlayer2.omxplayer', args=['--loop'])
 			media.pause()
 			VIDEO_PATH = value
 			return
@@ -82,7 +82,7 @@ def parse_commands(*args):
 			_logger.info("%s command success.", command)
 		elif command=="set_rate":
 			fps = str(30 * float(value))
-			media = OMXPlayer(PEFIX_PATH + VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer', args=['--loop','--force-fps', fps])
+			media = OMXPlayer(PREFIX_PATH + VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer', args=['--loop','--force-fps', fps])
 			media.pause()
 			_logger.info("%s command success.", command)
 		elif command=="pause":

--- a/pvm.py
+++ b/pvm.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+from pathlib import Path
 from pythonosc import dispatcher, osc_server
 import argparse
 from omxplayer.player import OMXPlayer
@@ -7,12 +8,19 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 import sys
 
+# Place your videos in this folder for autostart
+HOME = str(Path.home()) + "/"  # The home directory, e.g. /home/pi/
+LOG_PATH = HOME + "PVM/log/"
+PEFIX_PATH = HOME + "Videos/"
+VIDEO_PATH = "jellyfish720p.mp4"
+IS_FILE_SET = False
+
 def _init_logger():
 	logger = logging.getLogger("PVM")
 	logger.setLevel(logging.INFO)
 	handler = logging.StreamHandler(sys.stderr)
 	# Check if the `log` directory exists, create one if not.
-	log_path = "/home/pi/PVM/log/{:%Y-%m-%d %H:%M:%S}.log"
+	log_path = LOG_PATH + "{:%Y-%m-%d %H:%M:%S}.log"
 	if not os.path.exists(log_path):
 		os.makedirs(log_path)
 	fileHandler = TimedRotatingFileHandler(log_path.format(datetime.now()),  when='midnight')
@@ -30,12 +38,7 @@ _init_logger()
 _logger = logging.getLogger("PVM")
 _logger.info("Logging system initiated in %s", LOG_PATH)
 
-# Place your videos in this folder for autostart
-LOG_PATH = "/home/pi/PVM/log/"
-PEFIX_PATH = "/home/pi/Videos/"
-VIDEO_PATH = "jellyfish720p.mp4"
 media = ""
-IS_FILE_SET = False
 
 def parse_commands(*args):
 	global media


### PR DESCRIPTION
Fixes #45, fixes #8. This change would use the user’s home directory to resolve the absolute path to the PVM folder. Now even if the user is not the default `pi` user on Raspberry Pi, our program will still run.

Also clarified the README.md according to OCH's suggestion on #37 