### PR TITLE
Two Ports Solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To use NTP to sync all Raspberry Pis' time in local network, please follow secti
 
 ## Videos
 
-Please save all the videos in the `/home/{your_user_name}/Videos/` folder for autostart. On Rapsberry Pi, your default directory should be `/home/pi/Videos/`.
+Please save all the videos in the `$HOME/Videos/` folder for autostart. On Rapsberry Pi, your default directory should be `/home/pi/Videos/`.
 
 
 ## Running
@@ -100,7 +100,14 @@ On each Pi device, start the script
 
 ```bash
 cd PVM
+# Activate python env
+source PVM/bin/activate
+# The default port is 8001
 python pvm.py
+# If you want a different port, example 8002
+python pvm.py --port 8002
+# Or with launsh script
+sh launsh.sh 8001
 ```
 
 Read the help
@@ -134,6 +141,8 @@ on the terminal run
 after the last line add
 
 `@lxterminal -e sh $HOME/PVM/launch.sh 8001`
+
+add one more if you need two videos output
 
 `@lxterminal -e sh $HOME/PVM/launch.sh 8002`
 
@@ -214,14 +223,15 @@ Also don't forget to checkout our [wiki](https://github.com/omarcostahamido/PVM/
 ### Logs
 Logs will be recorded by `pvm.py` during execution. These will be stored in the `log/` folder, within the install directory of `PVM` on the Raspberry Pi device. This folder will be created if it doesn't exist yet.
 
-Name convention for each log file is `{:%Y-%m-%d %H:%M:%S}.log`
+Name convention for each log file is `{:%Y-%m-%d %H:%M:%S}-$PORT.log`
 
 All output from the console is synchronized to the file in real-time.
 
 ```bash
-2022-10-31 13:34:21;INFO;Received command: file
-2022-10-31 13:34:21;INFO;Received value: jellyfish720p.mp4
-2022-10-31 13:34:21;INFO;File set: /home/pi/Videos/jellyfish720p.mp4
+2022-11-20 11:32:55.243;INFO;8001;Logging system initiated
+2022-11-20 11:32:55.243;INFO;8001;PVM - Pi Video Machine
+2022-11-20 11:32:55.244;INFO;8001;Omar Costa Hamido 2022
+2022-11-20 11:32:55.244;INFO;8001;Server now listenning on port 8001
 ```
 
 If you close the program and then reopen it, a new log file will be created.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ on the terminal run
 
 after the last line add
 
-`@lxterminal -e sh $HOME/PVM/launch.sh`
+`@lxterminal -e sh $HOME/PVM/launch.sh 8001`
+
+`@lxterminal -e sh $HOME/PVM/launch.sh 8002`
 
 Note: this is assuming that you clone this repo on your raspberry pi in the main /home/pi folder and followed the steps in the <a target="_self" href="#installation">Installation</a> section above.
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ source PVM/bin/activate
 python pvm.py
 # If you want a different port, example 8002
 python pvm.py --port 8002
-# Or with launsh script
-sh launsh.sh 8001
+# Or with launch script
+sh launch.sh 8001
 ```
 
 Read the help
@@ -123,10 +123,13 @@ optional arguments:
                  Default port is 8001
 ```
 
-On the control machine first edit the [max-init.txt](https://github.com/omarcostahamido/PVM/blob/main/max-init.txt) file. For each Pi device add a numbered line with the video filename, ip, and port. As in:
+On the control machine first edit the [max-init.txt](https://github.com/omarcostahamido/PVM/blob/main/max-init.txt) file. For each Pi device add a numbered line with the video filename, ip, and port. 
+By default, we use port 8001 to receive UDP for our main display. 8002 is used for additional displays. 
+As in:
 
 ```
 1, jellyfish720.mp4 192.168.1.108 8001;
+2, jellyfish720.mp4 192.168.1.108 8002;
 ```
 
 Then proceed to launch the main control interface: `pvm.maxproj`. The `pvm.maxpat` patch should automatically open. 

--- a/build_omxplayer.sh
+++ b/build_omxplayer.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
+# How to run this?
+# In your console, just run `./build_omxplayer.sh`
 set -eou pipefail
 
 cd /home/pi
-git clone https://github.com/KaneBetter/omxplayer.git
-cd omxplayer
+# Check if omxplayer exists
+if [ -d "/omxplayer" ] 
+then
+	echo "Directory /omxplayer does not exists, clone from github."
+	git clone https://github.com/KaneBetter/omxplayer.git
+	cd omxplayer
+else
+	echo "Directory /omxplayer exists, run git pull" 
+	cd omxplayer
+	git pull
+fi
 
+# Update apt and install requirments
 sudo apt-get update && sudo apt install -y git libasound2-dev libva2 libpcre3-dev libidn11-dev libboost-dev libdbus-1-dev libssh-dev libsmbclient-dev libssl-dev
 
-# see https://github.com/popcornmix/omxplayer/issues/731
+# See https://github.com/popcornmix/omxplayer/issues/731
 sed -i -e 's/git-core/git/g' prepare-native-raspbian.sh
 sed -i -e 's/libva1/libva2/g' prepare-native-raspbian.sh
 sed -i -e 's/libssl1.0-dev/libssl-dev/g' prepare-native-raspbian.sh
@@ -16,6 +28,9 @@ sed -i -e 's/--enable-libsmbclient/--disable-libsmbclient/g' Makefile.ffmpeg
 ./prepare-native-raspbian.sh
 make ffmpeg
 
+# Copy new version of omxplayer into your system path
 make -j$(nproc)
 make dist
 sudo make install
+# Now you can use new version of omxplayer in your console,
+# example, omxplayer jellyfish.mp4

--- a/launch.sh
+++ b/launch.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 . ${HOME}/PVM/PVM/bin/activate
-python ${HOME}/PVM/pvm.py
+python ${HOME}/PVM/pvm.py --port $1

--- a/pvm.py
+++ b/pvm.py
@@ -78,7 +78,7 @@ def parse_commands(*args):
 	try:
 		# File command
 		if command=="file":
-    		# If the file is already set, we exit OMX first
+			# If the file is already set, we exit OMX first
 			if IS_FILE_SET:
 				OMX.quit()
 				_logger.info("Quit previous file: %s", VIDEO_PATH)

--- a/pvm.py
+++ b/pvm.py
@@ -125,15 +125,8 @@ def parse_commands(*args):
 			OMX.set_position(float(value))
 			_logger.info("%s command success.", command)
 		elif command=="set_rate":
-			fps = get_rate(value)
-			if IS_FILE_SET:
-				OMX.quit()
-			params = params + ['--force-fps', fps]
-			OMX = OMXPlayer(VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer1', args=params)
-			OMX.pause()
-			CAN_START = True
-			CAN_PAUSE = False
-			_logger.info("%s command success set rate: %s. You can start now!", command, fps)
+			OMX.set_rate(float(value))
+			_logger.info("%s command success set rate: %s.", command, value)
 		else:
 			_logger.info("%s unknown.", command)
 	except Exception as e:
@@ -159,20 +152,6 @@ def _init_logger():
 	logger.addHandler(fileHandler)
 	handler.setFormatter(formatter)
 	logger.addHandler(handler)
-
-# get fps from video path
-def get_rate(value):
-	global VIDEO_PATH
-	video_info = subprocess.Popen(["omxplayer", "-i", VIDEO_PATH], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-	out, _ = video_info.communicate()
-	out = out.decode(encoding='utf-8')
-	splist = out.split(", ")
-	for s in splist:
-		if 'fps' in s:
-			fps_info = s.split(' ')
-			original_fps = float(fps_info[0])
-	fps = str(original_fps * float(value))
-	return fps
 
 def main(RECEIVE_PORT):
 	#OSC server

--- a/pvm.py
+++ b/pvm.py
@@ -84,7 +84,10 @@ def parse_commands(*args):
 				_logger.info("Quit previous file: %s", VIDEO_PATH)
 				IS_FILE_SET = False
 			VIDEO_PATH = PREFIX_VIDEOS_PATH + value
-			OMX = OMXPlayer(VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer1', args=params)
+			if PORT == 8001:
+				OMX = OMXPlayer(VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer1', args=params)
+			else:
+				OMX = OMXPlayer(VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer2', args=params)	
 			# Because OMX has no user interface and will play automatically once the OMXPlayer object is created, 
 			# we need to call the puase() method after it is created.
 			OMX.pause()

--- a/pvm.py
+++ b/pvm.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import os
 from pathlib import Path
+import subprocess
 from time import sleep
 from pythonosc import dispatcher, osc_server
 import argparse
@@ -9,84 +10,88 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 import sys
 
-# Place your videos in this folder for autostart
+'''
+Global variables used in the program
+'''
 HOME = str(Path.home()) + "/"  # The home directory, e.g. /home/pi/
-LOG_PATH = HOME + "PVM/log/"
-PREFIX_PATH = HOME + "Videos/"
-VIDEO_PATH = "jellyfish720p.mp4"
-IS_FILE_SET = False
-
-def _init_logger():
-	logger = logging.getLogger("PVM")
-	logger.setLevel(logging.INFO)
-	handler = logging.StreamHandler(sys.stderr)
-	# Check if the `log` directory exists, create one if not.
-	log_path = LOG_PATH + "{:%Y-%m-%d %H:%M:%S}.log"
-	if not os.path.exists(log_path):
-		os.makedirs(log_path)
-	fileHandler = TimedRotatingFileHandler(log_path.format(datetime.now()),  when='midnight')
-	global LOG_PATH
-	LOG_PATH = log_path.format(datetime.now())
-	handler.setLevel(logging.INFO)
-	formatter = logging.Formatter("%(asctime)s.%(msecs)03d;%(levelname)s;%(message)s",
-							  "%Y-%m-%d %H:%M:%S")
-	fileHandler.setFormatter(formatter)
-	logger.addHandler(fileHandler)
-	handler.setFormatter(formatter)
-	logger.addHandler(handler)
-
-_init_logger()
-_logger = logging.getLogger("PVM")
-_logger.info("Logging system initiated in %s", LOG_PATH)
-
-media = ""
+LOG_PATH = HOME + "PVM/log/" # Log path
+PREFIX_VIDEOS_PATH = HOME + "Videos/" # Place your videos in this folder for autostart
+VIDEO_PATH = None # Video path
+OMX = None	# OMXPlayer object
+IS_FILE_SET = False # File set flag
+CAN_PAUSE = False # Can pause flag
+CAN_START = False # Can start flag
 
 '''
 UDP command example:
 /PVM HH MM SS <command> <value>
 '''
-
 def parse_commands(*args):
-	global media
+	global OMX
+	global PREFIX_VIDEOS_PATH
 	global VIDEO_PATH
 	global IS_FILE_SET
-	
-	# Parse time and add 3 seconds
-	hh, mm, ss = args[1], args[2], args[3]
-	time_str = str(hh) + ":" + str(mm) + ":" + str(ss)
-	next_time = datetime.strptime(time_str, "%H:%M:%S") + timedelta(seconds=3)
+	global CAN_START
+	global CAN_PAUSE
+	global PORT
 
 	# Get command
 	command = args[4]
-
-	# If scheduled time is behind current time, return.
-	if next_time.time() <= datetime.now().time():
-		_logger.info("Command: %s failed because scheduled time(%s) is behind current time.", command, time_str)
-		return
-
-	# Log command and execute time.
-	_logger.info("Command: %s, execute time: %s.", command, next_time.time())
 	
-	# Wait until current time is equal to next_time
-	while True:
-		now = datetime.now()
-		now = now.replace(microsecond=0)
-		if now.time() >= next_time.time():
-			break
-		sleep(0.005)
-	
-    # Get value
-	if len(args) == 6:
+	# Only start and pause command need to delay 3s
+	if command == "start" or command == "pause":
+		# Parse time and add 3 seconds
+		hh, mm, ss = args[1], args[2], args[3]
+		time_str = str(hh) + ":" + str(mm) + ":" + str(ss)
+		next_time = datetime.strptime(time_str, "%H:%M:%S") + timedelta(seconds=3)
+
+		# If scheduled time is behind current time, return.
+		# In very rare cases, the control computer will have a three-second time difference with the Raspberry Pi
+		if next_time.time() <= datetime.now().time():
+			_logger.info("Command: %s failed because scheduled time(%s) is behind current time.", command, time_str)
+			return
+
+		# Log command and execute time.
+		_logger.info("Command: %s, execute time: %s.", command, next_time.time())
+		
+		# Wait until current time is equal to next_time
+		while True:
+			now = datetime.now()
+			now = now.replace(microsecond=0)
+			if now.time() >= next_time.time():
+				break
+			sleep(0.005)
+
+	# Get value
+	if len(args) >= 6:
 		value = args[5]
 
+	# If PORT == 8001, we export our video in the main display 2,
+	# else we export our video on the extra display 7
+	params = ['--loop', '--display']
+	if PORT == 8001:
+		params.append('2')
+	else:
+		params.append('7')
+
+	# Catch the excpetion if Dbus is down.
 	try:
 		# File command
 		if command=="file":
-			_logger.info("File set: %s", PREFIX_PATH + value)
+    		# If the file is already set, we exit OMX first
+			if IS_FILE_SET:
+				OMX.quit()
+				_logger.info("Quit previous file: %s", VIDEO_PATH)
+				IS_FILE_SET = False
+			VIDEO_PATH = PREFIX_VIDEOS_PATH + value
+			OMX = OMXPlayer(VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer1', args=params)
+			# Because OMX has no user interface and will play automatically once the OMXPlayer object is created, 
+			# we need to call the puase() method after it is created.
+			OMX.pause()
 			IS_FILE_SET = True
-			media = OMXPlayer(PREFIX_PATH + value, dbus_name='org.mpris.MediaPlayer2.omxplayer', args=['--loop'])
-			media.pause()
-			VIDEO_PATH = value
+			CAN_START = True
+			CAN_PAUSE = False
+			_logger.info("File set: %s. You can start now!", VIDEO_PATH)
 			return
 
 		# If file is unset, then we should not execute any command below.
@@ -95,68 +100,98 @@ def parse_commands(*args):
 			return
 
 		if command=="start":
-			if media.can_play():
-				media.play()
+			if CAN_START:
+				OMX.play()
+				CAN_START = False
+				CAN_PAUSE = True
+				_logger.info("%s command success.", command)
+			else:
+				_logger.info("%s command failed.", command)
+		elif command=="pause":
+			if CAN_PAUSE:
+				OMX.pause()
+				CAN_PAUSE = False
+				CAN_START = True
 				_logger.info("%s command success.", command)
 			else:
 				_logger.info("%s command failed.", command)
 		elif command=="stop":
-			if media.can_quit():
-				media.stop()
-				IS_FILE_SET = False
-				_logger.info("%s command success and file has been unset.", command)
-			else:
-				_logger.info("%s command failed.", command)
+			OMX.stop()
+			IS_FILE_SET = False
+			CAN_START = False
+			CAN_PAUSE = False
+			_logger.info("%s command success and %s has been unset.", command, VIDEO_PATH)
 		elif command=="set_position":
-			media.set_position(float(value))
+			OMX.set_position(float(value))
 			_logger.info("%s command success.", command)
 		elif command=="set_rate":
-			fps = str(30 * float(value))
-			media = OMXPlayer(PREFIX_PATH + VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer', args=['--loop','--force-fps', fps])
-			if media != "":
-				media.quit()
-				print("media quit")
-			original_fps = 30
-			video_info = subprocess.Popen(["omxplayer", "-i", PEFIX_PATH + VIDEO_PATH], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-			print("The command", ["omxplayer", "-i", PEFIX_PATH + VIDEO_PATH])
-			# info = video_info.stdout.decode().split(", ")
-			out, err = video_info.communicate()
-			out = out.decode(encoding='utf-8')
-			splist = out.split(", ")
-			for s in splist:
-				if 'fps' in s:
-					print("current ele:", s)
-					fps_info = s.split(' ')
-					original_fps = float(fps_info[0])
-			fps = str(original_fps * float(value))
-			print("computed fps", fps)
-			media = OMXPlayer(PREFIX_PATH + VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer1', args=['--loop','--force-fps', fps])
-			media.pause()
-			_logger.info("%s command success.", command)
-		elif command=="pause":
-			if media.can_pause():
-				media.pause()
-				_logger.info("%s command success.", command)
-			else:
-				_logger.info("%s command failed.", command)
+			fps = get_rate(value)
+			if IS_FILE_SET:
+				OMX.quit()
+			params = params + ['--force-fps', fps]
+			OMX = OMXPlayer(VIDEO_PATH, dbus_name='org.mpris.MediaPlayer2.omxplayer1', args=params)
+			OMX.pause()
+			CAN_START = True
+			CAN_PAUSE = False
+			_logger.info("%s command success set rate: %s. You can start now!", command, fps)
 		else:
 			_logger.info("%s unknown.", command)
 	except Exception as e:
 		# `logger#exception method prints the stack trace`
 		_logger.exception("Function: parse_commands failed! %s" % (e))
 
+def _init_logger():
+	global LOG_PATH
+	global PORT
+	logger = logging.getLogger("PVM")
+	logger.setLevel(logging.INFO)
+	handler = logging.StreamHandler(sys.stderr)
+	# Check if the `log` directory exists, create one if not.
+	log_path = LOG_PATH + "{:%Y-%m-%d %H:%M:%S}-" + str(PORT) + ".log"
+	if not os.path.exists(LOG_PATH):
+		os.makedirs(LOG_PATH)
+	fileHandler = TimedRotatingFileHandler(log_path.format(datetime.now()),  when='midnight')
+	LOG_PATH = log_path.format(datetime.now())
+	handler.setLevel(logging.INFO)
+	formatter = logging.Formatter("%(asctime)s.%(msecs)03d;%(levelname)s;" + str(PORT) + ";%(message)s",
+							  "%Y-%m-%d %H:%M:%S")
+	fileHandler.setFormatter(formatter)
+	logger.addHandler(fileHandler)
+	handler.setFormatter(formatter)
+	logger.addHandler(handler)
+
+# get fps from video path
+def get_rate(value):
+	global VIDEO_PATH
+	video_info = subprocess.Popen(["omxplayer", "-i", VIDEO_PATH], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+	out, _ = video_info.communicate()
+	out = out.decode(encoding='utf-8')
+	splist = out.split(", ")
+	for s in splist:
+		if 'fps' in s:
+			fps_info = s.split(' ')
+			original_fps = float(fps_info[0])
+	fps = str(original_fps * float(value))
+	return fps
+
 def main(RECEIVE_PORT):
 	#OSC server
 	callback = dispatcher.Dispatcher()
 	server = osc_server.ThreadingOSCUDPServer(("", RECEIVE_PORT), callback)
-	print("server now listenning on port "+str(RECEIVE_PORT))
+	_logger.info("Server now listenning on port "+str(RECEIVE_PORT))
 	callback.map("/PVM", parse_commands)
 	server.serve_forever()
 
 if __name__ == '__main__':
+	global PORT
+	global _logger
 	p = argparse.ArgumentParser()
 	p.add_argument('--port', type=int, nargs='?', default=8001, help='The port that pvm.py will use to receive control messages. Default port is 8001')
 	args = p.parse_args()
-	print('PVM - Pi Video Machine')
-	print('Omar Costa Hamido 2022')
-	main(args.port)
+	PORT = args.port
+	_init_logger()
+	_logger = logging.getLogger("PVM")
+	_logger.info("Logging system initiated")
+	_logger.info("PVM - Pi Video Machine")
+	_logger.info("Omar Costa Hamido 2022")
+	main(PORT)

--- a/pvm.py
+++ b/pvm.py
@@ -39,7 +39,7 @@ def parse_commands(*args):
 	command = args[4]
 	
 	# Only start and pause command need to delay 3s
-	if command == "start" or command == "pause":
+	if command == "start" or command == "pause" or command == "set_rate":
 		# Parse time and add 3 seconds
 		hh, mm, ss = args[1], args[2], args[3]
 		time_str = str(hh) + ":" + str(mm) + ":" + str(ss)


### PR DESCRIPTION
Fixes #51 

Changed autostart section.
Changed log section.
Changed run section.
Rewrite pvm.py to accommodate different variations of PORT.
Update build_omxplayer.sh with instructions and folder check.

In this version, we can control two displays independently.